### PR TITLE
Allow use with chai < 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/chai-as-promised.js.html"
     },
     "peerDependencies": {
-        "chai": ">= 1.7.0 < 2"
+        "chai": ">= 1.7.0 < 3"
     },
     "devDependencies": {
         "chai": "~1.9.0",


### PR DESCRIPTION
chai@2.0.0 removes `addChainableNoop`, which was introduced in 1.10.0.

Since that function isn't used by chai-as-promised, it should still be
compatible.