### PR TITLE
Implemented ability to flatten expected values. It fixes #67

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -26,6 +26,10 @@
         assertion.then = promise.then.bind(promise);
     };
 
+    chaiAsPromised.transformAsserterArgs = function (values) {
+        return values;
+    };
+
     function chaiAsPromised(chai, utils) {
         var Assertion = chai.Assertion;
         var assert = chai.assert;
@@ -300,6 +304,9 @@
                 // just the base Chai code that we get to via the short-circuit above.
                 assertion._obj = value;
                 utils.flag(assertion, "eventually", false);
+
+                return args ? chaiAsPromised.transformAsserterArgs(args) : args;
+            }).then(function (args) {
                 asserter.apply(assertion, args);
 
                 // Because asserters, for example `property`, can change the value of `_obj` (i.e. change the "object"

--- a/test/browser/libraries/q.coffee
+++ b/test/browser/libraries/q.coffee
@@ -8,4 +8,5 @@ exports.adapter = """
     global.fulfilledPromise = Q;
     global.rejectedPromise = Q.reject;
     global.defer = Q.defer;
+    global.waitAll = Q.all;
 """

--- a/test/browser/libraries/when.coffee
+++ b/test/browser/libraries/when.coffee
@@ -25,4 +25,5 @@ exports.adapter = """
         return deferred.promise;
     };
     global.defer = when.defer;
+    global.waitAll = when.all;
 """

--- a/test/configurable-asserter-args.coffee
+++ b/test/configurable-asserter-args.coffee
@@ -1,0 +1,25 @@
+"use strict"
+
+describe "Configuring the way in which asserter arguments are transformed", =>
+    transformAsserterArgs = chaiAsPromised.transformAsserterArgs
+
+    beforeEach =>
+      chaiAsPromised.transformAsserterArgs = waitAll
+
+    afterEach =>
+        chaiAsPromised.transformAsserterArgs = transformAsserterArgs
+
+    it "should override transformAsserterArgs and allow to compare promises", =>
+        value = "test it"
+
+        fulfilledPromise(value).should.eventually.equal(fulfilledPromise(value))
+
+    it "should override transformAsserterArgs and wait until all promises are resolved", =>
+        fulfilledPromise(5).should.eventually.be.within(fulfilledPromise(3), fulfilledPromise(6))
+
+    it "should not invoke transformAsserterArgs for chai properties", =>
+        chaiAsPromised.transformAsserterArgs = =>
+            throw new Error("transformAsserterArgs should not be called for chai properties")
+
+        fulfilledPromise(true).should.eventually.be.true
+

--- a/test/support/node.js
+++ b/test/support/node.js
@@ -16,3 +16,4 @@ global.assert = chai.assert;
 global.fulfilledPromise = Q.resolve;
 global.rejectedPromise = Q.reject;
 global.defer = Q.defer;
+global.waitAll = Q.all;


### PR DESCRIPTION
It allows clients to implement an ability to compare promises' values:
```js
chaiAsPromised.flattenExpectedValues = function(values) {
  return values ? q.all(values) : [];
};

//then in the test
expect(user.getRole()).to.eventually.equal(Role.get('admin'));
```