### PR TITLE
do not instantiate error object in rejectedWith

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -153,7 +153,7 @@
                 Constructor = null;
                 message = null;
             } else if (typeof Constructor === "function") {
-                constructorName = (new Constructor()).name;
+                constructorName = Constructor.prototype.name;
             } else {
                 Constructor = null;
             }


### PR DESCRIPTION
Calling the constructor of an error leads to problems if the constructor requires arguments to be passed in. This is a safer way to get the name of the error.