### PR TITLE
Update Node setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Do an `npm install chai-as-promised` to get up and running. Then:
 var chai = require("chai");
 var chaiAsPromised = require("chai-as-promised");
 
+chai.should();
 chai.use(chaiAsPromised);
 ```
 


### PR DESCRIPTION
Add ```chai.should()``` call along with registering ```chaiAsPromised```. This seems to be necessary in order to call ```.should``` on a promise, but I couldn't find it explicitly mentioned anywhere in the docs.