### PR TITLE
Support for chai@3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
         "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/chai-as-promised.js.html"
     },
     "peerDependencies": {
-        "chai": ">= 2.1.2 < 3"
+        "chai": ">= 2.1.2 < 4"
     },
     "devDependencies": {
-        "chai": "^2.1.2",
+        "chai": "^3.0.0",
         "coffee-script": "1.9.0",
         "istanbul": "0.3.5",
         "ecstatic": "0.5.8",

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -116,11 +116,11 @@ describe "Promise-specific extensions:", =>
             describe ".rejectedWith('quux')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith("quux")
-                    message: "to be rejected with an error including 'quux' but got 'foo bar'"
+                    message: "to be rejected with an error including 'quux' but got 'Error: foo bar'"
             describe ".rejectedWith(/quux/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(/quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'foo bar'"
+                    message: "to be rejected with an error matching /quux/ but got 'Error: foo bar'"
 
             describe ".not.rejectedWith('foo')", =>
                 shouldFail
@@ -168,11 +168,11 @@ describe "Promise-specific extensions:", =>
             describe ".rejectedWith(RangeError, 'quux')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(RangeError, "quux")
-                    message: "to be rejected with an error including 'quux' but got 'foo bar'"
+                    message: "to be rejected with an error including 'quux' but got 'RangeError: foo bar'"
             describe ".rejectedWith(RangeError, /quux/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(RangeError, /quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'foo bar'"
+                    message: "to be rejected with an error matching /quux/ but got 'RangeError: foo bar'"
 
             describe ".rejectedWith(TypeError, 'foo')", =>
                 shouldFail


### PR DESCRIPTION
Bumped the peerDependencies range to < chai@4.0.0 to allow for chai 3.0.0 support.