### PR TITLE
Support jQuery >= 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Promise.resolve(2).should.eventually.be.within(Promise.resolve(1), Promise.resol
 
 ### Compatibility
 
-Chai as Promised is compatible with all promises following the [Promises/A+ specification][spec]. Notably, jQuery's so-called “promises” are not up to spec, and Chai as Promised will not work with them. In particular, Chai as Promised makes extensive use of the standard [transformation behavior][] of `then`, which jQuery does not support.
+Chai as Promised is compatible with all promises following the [Promises/A+ specification][spec]. Notably, jQuery's promises were not up to spec before jQuery 3.0, and Chai as Promised will not work with them. In particular, Chai as Promised makes extensive use of the standard [transformation behavior][] of `then`, which jQuery<3.0 does not support.
 
 ### Working with Non-Promise–Friendly Test Runners
 

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -34,8 +34,11 @@
         var Assertion = chai.Assertion;
         var assert = chai.assert;
 
-        function isJQueryPromise(thenable) {
-            return typeof thenable.always === "function" &&
+        function isLegacyJQueryPromise(thenable) {
+            // jQuery promises are Promises/A+-compatible since 3.0.0. jQuery 3.0.0 is also the first version
+            // to define the catch method.
+            return typeof thenable.catch !== "function" &&
+                   typeof thenable.always === "function" &&
                    typeof thenable.done === "function" &&
                    typeof thenable.fail === "function" &&
                    typeof thenable.pipe === "function" &&
@@ -47,9 +50,10 @@
             if (typeof assertion._obj.then !== "function") {
                 throw new TypeError(utils.inspect(assertion._obj) + " is not a thenable.");
             }
-            if (isJQueryPromise(assertion._obj)) {
-                throw new TypeError("Chai as Promised is incompatible with jQuery's thenables, sorry! Please use a " +
-                                    "Promises/A+ compatible library (see http://promisesaplus.com/).");
+            if (isLegacyJQueryPromise(assertion._obj)) {
+                throw new TypeError("Chai as Promised is incompatible with thenables of jQuery<3.0.0, sorry! Please " +
+                                    "upgrade jQuery or use another Promises/A+ compatible library (see " +
+                                    "http://promisesaplus.com/).");
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test": "npm run test-plugin && npm run test-intercompatibility",
         "test-plugin": "mocha",
         "test-intercompatibility": "mocha test-intercompatibility --opts test-intercompatibility/mocha.opts",
+        "test-browser-jquery": "coffee ./test/browser/runner.coffee jquery",
         "test-browser-q": "coffee ./test/browser/runner.coffee q",
         "test-browser-when": "coffee ./test/browser/runner.coffee when",
         "lint": "jshint ./lib",

--- a/test/browser/libraries/jquery.coffee
+++ b/test/browser/libraries/jquery.coffee
@@ -1,0 +1,36 @@
+"use strict"
+
+exports.name = "jQuery"
+
+exports.uri = "https://code.jquery.com/jquery-3.0.0-beta1.js"
+
+exports.adapter = """
+    global.fulfilledPromise = function (value) {
+        var deferred = jQuery.Deferred();
+        deferred.resolve(value);
+        return deferred.promise();
+    };
+    global.rejectedPromise = function (reason) {
+        var deferred = jQuery.Deferred();
+        deferred.reject(reason);
+        return deferred.promise();
+    };
+    global.defer = function () {
+        var deferred = jQuery.Deferred();
+        return {
+            promise: deferred.promise(),
+            resolve: deferred.resolve,
+            reject: deferred.reject,
+        };
+    };
+    global.getPromise = function (deferred) {
+        return deferred.promise();
+    };
+    global.waitAll = function (promises) {
+        return jQuery.when
+            .apply(null, promises)
+            .then(function () {
+                return Array.prototype.slice.call(arguments);
+            });
+    };
+"""


### PR DESCRIPTION
I need some help here. I tried to mimick `when` config; when I run `npm run test-browser-jquery`, I get 3 failures (much better than >100 of them with jQuery 2.1.4 but still):
![screen shot 2015-08-25 at 21 53 47](https://cloud.githubusercontent.com/assets/1758366/9477749/e2c55458-4b73-11e5-889a-8e218e74183e.png)
![screen shot 2015-08-25 at 21 53 57](https://cloud.githubusercontent.com/assets/1758366/9477751/e54c8be2-4b73-11e5-8f13-c529c17be89d.png)

First of them is in [lib/chai-as-promised.js#L308](https://github.com/mzgol/chai-as-promised/blob/c90ec43884a960da64c026b3c809ee9a88c7cfcf/lib/chai-as-promised.js#L308) where `args` is set to `"test it"` and should be an array-like.

What's the expected definition of `global.waitAll`? Test results didn't change when I removed it; is it needed?

I wasn't sure what version you want to include so I used the link to the latest `master` one as I believe that's what you have for `when`. I can change it to `3.0.0-alpha1` if you prefer it to be more deterministic.

There are two bugs related to jQuery Deferreds that I linked in the adapter file (they should both be fixed before the final 3.0.0) but they're both with `jQuery.when`, not `thenable.then`; the latter should work.