### PR TITLE
Recognize thrown errors for chai 3.0.0+

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -192,7 +192,8 @@
                                     reason);
                     }
 
-                    var reasonMessage = utils.type(reason) === "object" && "message" in reason ?
+                    var reasonType = utils.type(reason);
+                    var reasonMessage = (reasonType === "object" || reasonType === "error") && "message" in reason ?
                                             reason.message :
                                             "" + reason;
                     if (message && reasonMessage !== null && reasonMessage !== undefined) {


### PR DESCRIPTION
As of [v3.0.0](https://github.com/chaijs/chai/releases/tag/3.0.0) chai utils.type() returns "error" for Error objects.

Edit: the reason this is annoying is because this makes the error message matching different for `assert.throws` vs `assert.isRejected`. Since chai-as-promised doesn't recognize Error objects as such, it uses `.toString()`, which prefixes "Error: " to the message.