### PR TITLE
Allow messages to be passed through for "should.become"

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -233,8 +233,8 @@
             doNotify(getBasePromise(this), done);
         });
 
-        method("become", function (value) {
-            return this.eventually.deep.equal(value);
+        method("become", function (value, message) {
+            return this.eventually.deep.equal(value, message);
         });
 
         ////////

--- a/test/should-eventually.coffee
+++ b/test/should-eventually.coffee
@@ -145,3 +145,24 @@ describe "Fulfillment value assertions:", =>
 
         describe ".eventually.have.property('foo').that.equals('bar')", =>
             shouldPass => promise.should.eventually.have.property('foo').that.equals('bar')
+
+    describe "Become messages", =>
+        message = "He told me enough! He told me you killed him!"
+
+        beforeEach =>
+            promise = fulfilledPromise(42)
+            return undefined
+
+        describe "should pass through for .become(value, message) for 42", =>
+            shouldPass => promise.should.become(42, message)
+        describe "should pass through for .become(value, message) for 52", =>
+            shouldFail
+                op: => promise.should.become(52, message)
+                message: message
+
+        describe "should pass through for .not.become(42, message)", =>
+            shouldFail
+                op: => promise.should.not.become(42, message)
+                message: message
+        describe "should pass through for .not.become(52, message)", =>
+            shouldPass => promise.should.not.become(52, message)


### PR DESCRIPTION
Updated to match same message pattern used by `assert.becomes`.