### PR TITLE
Fixed issue #148:

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -1,4 +1,4 @@
-(function () {
+(function (callingContext) {
     "use strict";
 
     // Module systems magic dance.
@@ -19,7 +19,13 @@
         chai.use(chaiAsPromised);
 
         // Expose as a property of the global object so that consumers can configure the `transferPromiseness` property.
-        self.chaiAsPromised = chaiAsPromised;
+				if(typeof self !== "undefined") {
+					//Used in karma where the browser has a self variable set.
+        	self.chaiAsPromised = chaiAsPromised;
+				} else {
+					//Used in karma and others where the running context does not have a self variable set.
+					if(typeof callingContext !=="undefined") callingContext.chaiAsPromised = chaiAsPromised;
+				}
     }
 
     chaiAsPromised.transferPromiseness = function (assertion, promise) {
@@ -372,4 +378,4 @@
             };
         });
     }
-}());
+}(this));


### PR DESCRIPTION
Fixed issue #148 by passing in a calling context (this) and setting chaiAsPromised as a field on that context object. Fixes self is undefined issue when using the module with Karma when not run under a browser. Yet still maintains the ability to override chaiAsPromised.transferPromiseness.

Inspiration taken from how [moment.js](https://github.com/moment/moment/blob/develop/moment.js) loads modules.

This build still passes all tests.