### PR TITLE
Fixing the documentation for chaiAsPromised.transformAsserterArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ chaiAsPromised.transformAsserterArgs = function (args) {
 }
 
 Promise.resolve(2).should.eventually.equal(2); // will now fail!
-Promise.resolve(2).should.eventually.equal(3); // will now pass!
+Promise.resolve(3).should.eventually.equal(2); // will now pass!
 ```
 
 The transform can even be asynchronous, returning a promise for an array instead of an array directly. An example of that might be using `Promise.all` so that an array of promises becomes a promise for an array. If you do that, then you can compare promises against other promises using the asserters:

--- a/test/configurable-asserter-args.coffee
+++ b/test/configurable-asserter-args.coffee
@@ -23,3 +23,8 @@ describe "Configuring the way in which asserter arguments are transformed", =>
 
         fulfilledPromise(true).should.eventually.be.true
 
+    it "should transform asserter args", =>
+        chaiAsPromised.transformAsserterArgs = (args) =>
+            (x + 1 for x in args)
+
+        fulfilledPromise(3).should.eventually.equal(2)


### PR DESCRIPTION
Updating the documentation for [Transforming Arguments to the Asserters](https://github.com/domenic/chai-as-promised#transforming-arguments-to-the-asserters) from 
`Promise.resolve(2).should.eventually.equal(3); // will now pass!` to `Promise.resolve(3).should.eventually.equal(2); // will now pass!` (switching 2 and 3)

And adding a test case for that.