### PR TITLE
Add missing stack trace for native promises

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -1,12 +1,16 @@
 (function () {
     "use strict";
 
+    var pathSep;
+
     // Module systems magic dance.
 
     /* istanbul ignore else */
     if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
         // NodeJS
         module.exports = chaiAsPromised;
+
+        pathSep = require("path").sep;
     } else if (typeof define === "function" && define.amd) {
         // AMD
         define(function () {
@@ -92,6 +96,25 @@
             return typeof assertion.then === "function" ? assertion : assertion._obj;
         }
 
+        function fixErrorStack(realErr, fakeErr) {
+            // Because stack traces are lost due to asynchronicity, and thus won't be available once a promise resolves,
+            // we always create a fake error that captures the assertion's stack trace before it's lost. If an assertion
+            // fails, we are then able to restore the assertion's captured stack trace onto the assertion error.
+            realErr.stack = fakeErr.stack.replace("AssertionError: Unspecified AssertionError", 
+                                                  "AssertionError: " + realErr.message);
+
+            // Stack traces are very noisy with chai and chai-as-promised frames. Remove them unless configured not to.
+            // Note: This is skipped in browsers.
+            if (pathSep && !chai.config.includeStack) {
+                realErr.stack = realErr.stack.split("\n").filter(function (line) {
+                    return !~line.indexOf("node_modules" + pathSep + "chai-as-promised" + pathSep) &&
+                           !~line.indexOf("node_modules" + pathSep + "chai" + pathSep);
+                }).join("\n");
+            }
+
+            return realErr;
+        }
+
         // Grab these first, before we modify `Assertion.prototype`.
 
         var propertyNames = Object.getOwnPropertyNames(Assertion.prototype);
@@ -103,6 +126,10 @@
 
         property("fulfilled", function () {
             var that = this;
+
+            // Capture the assertion's stack trace before it's lost due to asynchronicity.
+            var fakeErr = new chai.AssertionError();
+
             var derivedPromise = getBasePromise(that).then(
                 function (value) {
                     that._obj = value;
@@ -116,13 +143,19 @@
                                        "expected promise to be fulfilled but it was rejected with #{act}",
                                        { actual: reason });
                 }
-            );
+            ).catch(function (realErr) {
+                throw fixErrorStack(realErr, fakeErr);
+            });
 
             chaiAsPromised.transferPromiseness(that, derivedPromise);
         });
 
         property("rejected", function () {
             var that = this;
+
+            // Capture the assertion's stack trace before it's lost due to asynchronicity.
+            var fakeErr = new chai.AssertionError();
+
             var derivedPromise = getBasePromise(that).then(
                 function (value) {
                     that._obj = value;
@@ -140,7 +173,9 @@
                     // `promise.should.be.rejected.and.eventually.equal("reason")`.
                     return reason;
                 }
-            );
+            ).catch(function (realErr) {
+                throw fixErrorStack(realErr, fakeErr);
+            });
 
             chaiAsPromised.transferPromiseness(that, derivedPromise);
         });
@@ -161,6 +196,9 @@
             } else {
                 Constructor = null;
             }
+
+            // Capture the assertion's stack trace before it's lost due to asynchronicity.
+            var fakeErr = new chai.AssertionError();
 
             var that = this;
             var derivedPromise = getBasePromise(that).then(
@@ -224,7 +262,9 @@
                                     reason);
                     }
                 }
-            );
+            ).catch(function (realErr) {
+                throw fixErrorStack(realErr, fakeErr);
+            });
 
             chaiAsPromised.transferPromiseness(that, derivedPromise);
         });
@@ -296,6 +336,9 @@
                 return asserter.apply(assertion, args);
             }
 
+            // Capture the assertion's stack trace before it's lost due to asynchronicity.
+            var fakeErr = new chai.AssertionError();
+
             var derivedPromise = getBasePromise(assertion).then(function (value) {
                 // Set up the environment for the asserter to actually run: `_obj` should be the fulfillment value, and
                 // now that we have the value, we're no longer in "eventually" mode, so we won't run any of this code,
@@ -311,6 +354,8 @@
                 // flag), we need to communicate this value change to subsequent chained asserters. Since we build a
                 // promise chain paralleling the asserter chain, we can use it to communicate such changes.
                 return assertion._obj;
+            }).catch(function (realErr) {
+                throw fixErrorStack(realErr, fakeErr);
             });
 
             chaiAsPromised.transferPromiseness(assertion, derivedPromise);
@@ -357,12 +402,17 @@
                     };
                 }
 
+                // Capture the assertion's stack trace before it's lost due to asynchronicity.
+                var fakeErr = new chai.AssertionError();
+
                 var returnedPromise = promise.then(
                     function (fulfillmentValue) {
                         return assert[assertMethodName].apply(assert, [fulfillmentValue].concat(otherArgs));
                     },
                     customRejectionHandler
-                );
+                ).catch(function (realErr) {
+                    throw fixErrorStack(realErr, fakeErr);
+                });
 
                 returnedPromise.notify = function (done) {
                     doNotify(returnedPromise, done);

--- a/test/stack-traces.coffee
+++ b/test/stack-traces.coffee
@@ -1,0 +1,71 @@
+"use strict"
+
+describe "Stack traces", =>
+    promise = null
+
+    shouldFailWithCorrectStack = (promiseProducer) =>
+        it "should return a promise rejected with an assertion error that has stack trace correct", (done) =>
+            expect(promiseProducer().then(
+                =>
+                    throw new Error("promise fulfilled")
+                (e) =>
+                    e.stack.should.match(/stack-traces\.coffee/)
+            )).to.be.fulfilled.notify(done)
+
+    describe "eventually", =>
+        beforeEach =>
+            promise = fulfilledPromise(42)
+            return undefined
+
+        describe "assert", =>
+            shouldFailWithCorrectStack => assert.eventually.equal(promise, 52)
+        describe "expect", =>
+            shouldFailWithCorrectStack => expect(promise).to.eventually.equal(52)
+        describe "should", =>
+            shouldFailWithCorrectStack => promise.should.eventually.equal(52)
+
+    describe "fulfilled", =>
+        beforeEach =>
+            promise = rejectedPromise()
+            return undefined
+
+        describe "assert", =>
+            shouldFailWithCorrectStack => assert.isFulfilled(promise)
+        describe "expect", =>
+            shouldFailWithCorrectStack => expect(promise).to.be.fulfilled
+        describe "should", =>
+            shouldFailWithCorrectStack => promise.should.be.fulfilled
+
+    describe "rejected", =>
+        beforeEach =>
+            promise = fulfilledPromise()
+            return undefined
+
+        describe "assert", =>
+            shouldFailWithCorrectStack => assert.isRejected(promise)
+        describe "expect", =>
+            shouldFailWithCorrectStack => expect(promise).to.be.rejected
+        describe "should", =>
+            shouldFailWithCorrectStack => promise.should.be.rejected
+
+    describe "rejectedWith", =>
+        beforeEach =>
+            promise = rejectedPromise(TypeError())
+            return undefined
+
+        describe "assert", =>
+            shouldFailWithCorrectStack => assert.isRejected(promise, ReferenceError)
+        describe "expect", =>
+            shouldFailWithCorrectStack => expect(promise).to.be.rejectedWith(ReferenceError)
+        describe "should", =>
+            shouldFailWithCorrectStack => promise.should.be.rejectedWith(ReferenceError)
+
+    describe "multiple", =>
+        beforeEach =>
+            promise = fulfilledPromise({a: 42})
+            return undefined
+
+        describe "expect", =>
+            shouldFailWithCorrectStack => expect(promise).to.eventually.have.property("a").that.equals(52)
+        describe "should", =>
+            shouldFailWithCorrectStack => promise.should.eventually.have.property("a").that.equals(52)

--- a/test/support/common.js
+++ b/test/support/common.js
@@ -4,9 +4,6 @@
 
 (function () {
     var Q = global.Q || (typeof require === "function" && require("q"));
-    if (Q) {
-        Q.longStackSupport = true;
-    }
 }());
 
 global.shouldPass = function (promiseProducer) {


### PR DESCRIPTION
This PR addresses #118 and https://github.com/chaijs/chai/issues/656.

Pinging for review/discussion: @domenic @keithamus @lucasfcosta @WhyEvenTry @jurko-gospodnetic @vdh

The root of the problem is that promises lose their stack traces due to their asynchronous nature. This causes failed assertions involving promises to display empty or unhelpful stack traces.

This problem affects:
- native promises
- Q promises (without `longStackSupport` enabled)
- Bluebird promises (without `longStackTraces` enabled)

This problem doesn't affect Q and Bluebird promises with their long stack options enabled.

This PR resolves the problem in a somewhat hacky manner by capturing an assertion's stack trace before it's lost due to asynchronicity, so that if an actual assertion error occurs, the stack trace can be copied over to the assertion error.

A side-effect of adding stack traces in this way (which was also previously true for Q and Bluebird promises with their long stack options enabled) is that the stack trace is a bit noisy with `chai` and `chai-as-promised` frames. Therefore, this PR also filters those frames out of the stack trace (when inside a NodeJS environment), unless `chai.config.includeStack` is set to `true`.

Consumers using Q or Bluebird will need to disable the long stack option in order to take advantage of these filtered stack traces.

It should also be noted that since the stack trace is created prior to the promise resolving, and thus prior to the actual assertion being performed, it will be missing one or more plumbing frames, though these missing frame(s) would be filtered out anyway unless `chai.config.includeStack` is set to `true`.

Tests were added to verify that the calling test's file is included in an assertion error's stack trace. Unfortunately, because `chai-as-promised` uses Q with `longStackTraces` enabled for its tests, these new tests pass even in `v5.3.0`. Therefore, this PR also changes `chai-as-promised`'s tests to no longer use `longStackTraces` so that the testing behavior is more in line with native promises. These new tests all fail in `v5.3.0` when `longStackTraces` is disabled, as expected.

Below is a short before/after example.

**Tests:**

```js
var chai = require("chai");
var chaiAsPromised = require("chai-as-promised");

chai.use(chaiAsPromised);

var expect = chai.expect;

it("eventually", function () {
  chai.config.includeStack = false;
  return expect(Promise.resolve(42)).to.eventually.equal(43);
});

it("eventually with chai.config.includeStack", function () {
  chai.config.includeStack = true;
  return expect(Promise.resolve(42)).to.eventually.equal(43);
});
```

**Before (v5.3.0):**

```
  1) eventually
  2) eventually with chai.config.includeStack

  0 passing (17ms)
  2 failing

  1)  eventually:

      AssertionError: expected 42 to equal 43
      + expected - actual

      -42
      +43



  2)  eventually with chai.config.includeStack:

      AssertionError: expected 42 to equal 43
      + expected - actual

      -42
      +43

      at assertEqual (node_modules/chai/lib/chai/core/assertions.js:487:12)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at node_modules/chai-as-promised/lib/chai-as-promised.js:308:26
```

**After (this PR):**

```
  1) eventually
  2) eventually with chai.config.includeStack

  0 passing (18ms)
  2 failing

  1)  eventually:

      AssertionError: expected 42 to equal 43
      + expected - actual

      -42
      +43

      at Context.<anonymous> (test/index.js:10:52)

  2)  eventually with chai.config.includeStack:

      AssertionError: expected 42 to equal 43
      + expected - actual

      -42
      +43

      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:340:27)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:295:21)
      at ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at Context.<anonymous> (test/index.js:15:52)
```