### PR TITLE
Support Chai@4 - Fix assertions broken by Chai 4.0

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -101,6 +101,7 @@ module.exports = function (chai, utils) {
         );
 
         module.exports.transferPromiseness(that, derivedPromise);
+        return that;
     });
 
     property("rejected", function () {
@@ -124,6 +125,7 @@ module.exports = function (chai, utils) {
         );
 
         module.exports.transferPromiseness(that, derivedPromise);
+        return that;
     });
 
     method("rejectedWith", function (errorLike, errMsgMatcher, message) {
@@ -135,8 +137,7 @@ module.exports = function (chai, utils) {
         if (errorLike === undefined && errMsgMatcher === undefined &&
             message === undefined) {
             /* jshint expr: true */
-            this.rejected;
-            return;
+            return this.rejected;
         }
 
         if (message !== undefined) {
@@ -224,14 +225,17 @@ module.exports = function (chai, utils) {
         );
 
         module.exports.transferPromiseness(that, derivedPromise);
+        return that;
     });
 
     property("eventually", function () {
         utils.flag(this, "eventually", true);
+        return this;
     });
 
     method("notify", function (done) {
         doNotify(getBasePromise(this), done);
+        return this;
     });
 
     method("become", function (value, message) {
@@ -249,7 +253,7 @@ module.exports = function (chai, utils) {
     methodNames.forEach(function (methodName) {
         Assertion.overwriteMethod(methodName, function (originalMethod) {
             return function () {
-                doAsserterAsyncAndAddThen(originalMethod, this, arguments);
+                return doAsserterAsyncAndAddThen(originalMethod, this, arguments);
             };
         });
     });
@@ -268,19 +272,19 @@ module.exports = function (chai, utils) {
                 getterName,
                 function (originalMethod) {
                     return function() {
-                        doAsserterAsyncAndAddThen(originalMethod, this, arguments);
+                        return doAsserterAsyncAndAddThen(originalMethod, this, arguments);
                     };
                 },
                 function (originalGetter) {
                     return function() {
-                        doAsserterAsyncAndAddThen(originalGetter, this);
+                        return doAsserterAsyncAndAddThen(originalGetter, this);
                     };
                 }
             );
         } else {
             Assertion.overwriteProperty(getterName, function (originalGetter) {
                 return function () {
-                    doAsserterAsyncAndAddThen(originalGetter, this);
+                    return doAsserterAsyncAndAddThen(originalGetter, this);
                 };
             });
         }
@@ -290,7 +294,8 @@ module.exports = function (chai, utils) {
         // Since we're intercepting all methods/properties, we need to just pass through if they don't want
         // `eventually`, or if we've already fulfilled the promise (see below).
         if (!utils.flag(assertion, "eventually")) {
-            return asserter.apply(assertion, args);
+            asserter.apply(assertion, args);
+            return assertion;
         }
 
         var derivedPromise = getBasePromise(assertion).then(function (value) {
@@ -311,6 +316,7 @@ module.exports = function (chai, utils) {
         });
 
         module.exports.transferPromiseness(assertion, derivedPromise);
+        return assertion;
     }
 
     ///////

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "check-error": "^1.0.2"
   },
   "peerDependencies": {
-    "chai": ">= 2.1.2 < 4"
+    "chai": ">= 2.1.2 < 5"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
+    "chai": "^4.0.0",
     "coffee-script": "1.10.0",
     "ecstatic": "^1.3.1",
     "glob": "^6.0.1",

--- a/test/should-eventually.coffee
+++ b/test/should-eventually.coffee
@@ -34,8 +34,8 @@ describe "Fulfillment value assertions:", =>
                 fulfilledPromise(foo: "baz").should.not.eventually.deep.equal(foo: "bar").notify(done)
             it ".eventually.not.deep.equal({ foo: 'bar' })", (done) =>
                 fulfilledPromise(foo: "baz").should.eventually.not.deep.equal(foo: "bar").notify(done)
-            it ".eventually.have.deep.property('foo.bar')", (done) =>
-                fulfilledPromise(foo: bar: "baz").should.eventually.have.deep.property("foo.bar", "baz").notify(done)
+            it ".eventually.have.nested.property('foo.bar')", (done) =>
+                fulfilledPromise(foo: bar: "baz").should.eventually.have.nested.property("foo.bar", "baz").notify(done)
             it ".eventually.contain('foo')", (done) =>
                 fulfilledPromise(["foo", "bar"]).should.eventually.contain("foo").notify(done)
             it ".not.eventually.contain('foo')", (done) =>


### PR DESCRIPTION
This PR addresses https://github.com/chaijs/chai/issues/723. To summarize:

- A change in Chai 4.0 causes assertions to lose their promiseness unless the promisified assertion object is explicitly returned
- A single test started failing with Chai 4.0 due to the replacement of `.deep` with `.nested`
- With this PR, `chai-as-promised` should now work with Chai 4.0 while continuing to work with older versions of Chai
