### PR TITLE
Add .pending assertion

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -145,6 +145,43 @@
             chaiAsPromised.transferPromiseness(that, derivedPromise);
         });
 
+        property("pending", function () {
+            var that = this;
+            var basePromise = getBasePromise(that);
+
+            var settleCatchingPromise = basePromise.then(
+                function (value) {
+                    that._obj = value;
+                    assertIfNotNegated(that,
+                                       "expected promise to be pending but it was fulfilled with #{act}",
+                                       { actual: value });
+                    return value;
+                },
+                function (reason) {
+                    assertIfNotNegated(that,
+                                    "expected promise to be pending but it was rejected with #{act}",
+                                    { actual: reason });
+
+                    // Return the reason, transforming this into a fulfillment, to allow further assertions, e.g.
+                    // `promise.should.not.be.pending.and.eventually.equal("reason")`.
+                    return reason;
+                }
+            );
+
+            // Resolve() is required to make this async, so it runs after the above.
+            var resolvingNowPromise = Promise.resolve().then(function () {
+                assertIfNegated(that,
+                                "expected promise not to be pending, but it was",
+                                { actual: basePromise });
+            });
+
+            // If base is already resolved, settleCatchingPromise resolves first and fails (unless
+            // negated). Otherwise resolvingNowPromise resolves first, and this fulfills (unless negated).
+            var racingPromise = Promise.race([settleCatchingPromise, resolvingNowPromise]);
+
+            chaiAsPromised.transferPromiseness(that, racingPromise);
+        });
+
         method("rejectedWith", function (Constructor, message) {
             var desiredReason = null;
             var constructorName = null;

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -168,11 +168,15 @@
                 }
             );
 
-            // Resolve() is required to make this async, so it runs after the above.
-            var resolvingNowPromise = Promise.resolve().then(function () {
-                assertIfNegated(that,
-                                "expected promise not to be pending, but it was",
-                                { actual: basePromise });
+            var resolvingNowPromise = new Promise(function (resolve) {
+                // setTimeout ensures this is scheduled as the next task, not microtask.
+                // This ensures all already due promises get run first.
+                setTimeout(function () {
+                    assertIfNegated(that,
+                                    "expected promise not to be pending, but it was",
+                                    { actual: basePromise });
+                    resolve();
+                }, 0);
             });
 
             // If base is already resolved, settleCatchingPromise resolves first and fails (unless


### PR DESCRIPTION
At the moment, you can only assert on .fulfilled and .rejected. In some cases though, I want to assert that my promise has *not* been resolved yet. In my specific case, I have a promise that blocks on user input. I want to check it does not resolve in various cases until input is completed.

With this change, I can now write:

```javascript
it("should not resolve initially", () => {
  var inputPromise = requestUserInput();
  return expect(inputPromise).to.be.pending; // passes
}
```

I'd initially assumed that `expect(promise).not.to.be.fulfilled` would get me close to this, but actually just times out if the base promise never resolves. As far as I can tell, there's no other nice way of doing this right now.

This is an interesting case as there's potential for false positives on these assertions due to race conditions if you use them carelessly (since you're just checking at a moment in time, and your promise could resolve 1 tick later). I think it's ok though, and it's certainly useful for my case as-is.

I believe by ensuring `resolvingNowPromise` resolves with setTimeout you guarantee that any promises already due to resolve will resolve before the assertion is checked, so the potential for race conditions is only in promises that are genuinely not ready to resolve yet. I think with this implementation you can't confusingly give yourself race conditions by using plain promises alone, but you might be able to if you assert on time-based promises very close to when they're due to resolve. I think that's obviously a bad idea though, and there's no real way to stop that.

Anyway, this is just a WIP PR to see whether you'd be happy to merge this, since I need the feature for my own tests anyway. Happy to add more detailed tests and docs here, and make any tweaks you'd like, if this is indeed something you're interested in.