### PR TITLE
Have promise rejection tests mirror how Chai tests exceptions.

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -105,7 +105,6 @@
             var that = this;
             var derivedPromise = getBasePromise(that).then(
                 function (value) {
-                    that._obj = value;
                     assertIfNegated(that,
                                     "expected promise not to be fulfilled but it was fulfilled with #{act}",
                                     { actual: value });
@@ -115,6 +114,7 @@
                     assertIfNotNegated(that,
                                        "expected promise to be fulfilled but it was rejected with #{act}",
                                        { actual: reason });
+                    return reason;
                 }
             );
 
@@ -125,7 +125,6 @@
             var that = this;
             var derivedPromise = getBasePromise(that).then(
                 function (value) {
-                    that._obj = value;
                     assertIfNotNegated(that,
                                        "expected promise to be rejected but it was fulfilled with #{act}",
                                        { actual: value });
@@ -183,9 +182,8 @@
                         expected = desiredReason;
                     }
 
-                    that._obj = value;
-
                     assertIfNotNegated(that, assertionMessage, { expected: expected, actual: value });
+                    return value;
                 },
                 function (reason) {
                     if (Constructor) {
@@ -223,6 +221,7 @@
                                     desiredReason,
                                     reason);
                     }
+                    return reason;
                 }
             );
 

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -1,26 +1,24 @@
-(function () {
+(function (factory) {
     "use strict";
-
-    // Module systems magic dance.
-
     /* istanbul ignore else */
     if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
         // NodeJS
-        module.exports = chaiAsPromised;
+        module.exports = factory();
     } else if (typeof define === "function" && define.amd) {
         // AMD
-        define(function () {
-            return chaiAsPromised;
-        });
+        define(factory);
     } else {
         /*global self: false */
 
         // Other environment (usually <script> tag): plug in to global chai instance directly.
+        var chaiAsPromised = factory();
         chai.use(chaiAsPromised);
 
         // Expose as a property of the global object so that consumers can configure the `transferPromiseness` property.
         self.chaiAsPromised = chaiAsPromised;
     }
+}(function () {
+    "use strict";
 
     chaiAsPromised.transferPromiseness = function (assertion, promise) {
         assertion.then = promise.then.bind(promise);
@@ -371,4 +369,6 @@
             };
         });
     }
-}());
+
+    return chaiAsPromised;
+}));

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -97,6 +97,10 @@
             return typeof assertion.then === "function" ? assertion : assertion._obj;
         }
 
+        function getReasonName(reason) {
+            return (reason instanceof Error) ? reason.toString() : checkError.getConstructorName(reason);
+        }
+
         // Grab these first, before we modify `Assertion.prototype`.
 
         var propertyNames = Object.getOwnPropertyNames(Assertion.prototype);
@@ -118,7 +122,7 @@
                 function (reason) {
                     assertIfNotNegated(that,
                                        "expected promise to be fulfilled but it was rejected with #{act}",
-                                       { actual: reason });
+                                       { actual: getReasonName(reason) });
                     return reason;
                 }
             );
@@ -138,7 +142,7 @@
                 function (reason) {
                     assertIfNegated(that,
                                     "expected promise not to be rejected but it was rejected with #{act}",
-                                    { actual: reason });
+                                    { actual: getReasonName(reason) });
 
                     // Return the reason, transforming this into a fulfillment, to allow further assertions, e.g.
                     // `promise.should.be.rejected.and.eventually.equal("reason")`.
@@ -149,21 +153,38 @@
             chaiAsPromised.transferPromiseness(that, derivedPromise);
         });
 
-        method("rejectedWith", function (Constructor, message) {
-            var desiredReason = null;
-            var constructorName = null;
+        method("rejectedWith", function (errorLike, errMsgMatcher, message) {
+            var errorLikeName = null;
+            var negate = utils.flag(this, "negate") || false;
 
-            if (Constructor instanceof RegExp || typeof Constructor === "string") {
-                message = Constructor;
-                Constructor = null;
-            } else if (Constructor && Constructor instanceof Error) {
-                desiredReason = Constructor;
-                Constructor = null;
-                message = null;
-            } else if (typeof Constructor === "function") {
-                constructorName = checkError.getConstructorName(Constructor);
+            // rejectedWith with that is called without arguments is
+            // the same as a plain ".rejected" use.
+            if (errorLike === undefined && errMsgMatcher === undefined &&
+                message === undefined) {
+                /* jshint expr: true */
+                this.rejected;
+                return;
+            }
+
+            if (message !== undefined) {
+                utils.flag(this, "message", message);
+            }
+
+            if (errorLike instanceof RegExp || typeof errorLike === "string") {
+                errMsgMatcher = errorLike;
+                errorLike = null;
+            } else if (errorLike && errorLike instanceof Error) {
+                errorLikeName = errorLike.toString();
+            } else if (typeof errorLike === "function") {
+                errorLikeName = checkError.getConstructorName(errorLike);
             } else {
-                Constructor = null;
+                errorLike = null;
+            }
+            var everyArgIsDefined = Boolean(errorLike && errMsgMatcher);
+
+            var matcherRelation = "including";
+            if (errMsgMatcher instanceof RegExp) {
+                matcherRelation = "matching";
             }
 
             var that = this;
@@ -172,60 +193,59 @@
                     var assertionMessage = null;
                     var expected = null;
 
-                    if (Constructor) {
+                    if (errorLike) {
                         assertionMessage = "expected promise to be rejected with #{exp} but it was fulfilled with " +
                                            "#{act}";
-                        expected = constructorName;
-                    } else if (message) {
-                        var verb = message instanceof RegExp ? "matching" : "including";
-                        assertionMessage = "expected promise to be rejected with an error " + verb + " #{exp} but it " +
-                                           "was fulfilled with #{act}";
-                        expected = message;
-                    } else if (desiredReason) {
-                        assertionMessage = "expected promise to be rejected with #{exp} but it was fulfilled with " +
-                                           "#{act}";
-                        expected = desiredReason;
+                        expected = errorLikeName;
+                    } else if (errMsgMatcher) {
+                        assertionMessage = "expected promise to be rejected with an error " + matcherRelation +
+                            " #{exp} but it was fulfilled with #{act}";
+                        expected = errMsgMatcher;
                     }
 
                     assertIfNotNegated(that, assertionMessage, { expected: expected, actual: value });
                     return value;
                 },
                 function (reason) {
-                    if (Constructor) {
-                        that.assert(reason instanceof Constructor,
-                                    "expected promise to be rejected with #{exp} but it was rejected with #{act}",
-                                    "expected promise not to be rejected with #{exp} but it was rejected with #{act}",
-                                    constructorName,
-                                    reason);
-                    }
+                    var errorLikeCompatible = errorLike && (errorLike instanceof Error ?
+                                                            checkError.compatibleInstance(reason, errorLike) :
+                                                            checkError.compatibleConstructor(reason, errorLike));
 
-                    var reasonMessage = utils.type(reason) === "object" && "message" in reason ?
-                                            reason.message :
-                                            "" + reason;
-                    if (message && reasonMessage !== null && reasonMessage !== undefined) {
-                        if (message instanceof RegExp) {
-                            that.assert(message.test(reasonMessage),
-                                        "expected promise to be rejected with an error matching #{exp} but got #{act}",
-                                        "expected promise not to be rejected with an error matching #{exp}",
-                                        message,
-                                        reasonMessage);
-                        }
-                        if (typeof message === "string") {
-                            that.assert(reasonMessage.indexOf(message) !== -1,
-                                        "expected promise to be rejected with an error including #{exp} but got #{act}",
-                                        "expected promise not to be rejected with an error including #{exp}",
-                                        message,
-                                        reasonMessage);
+                    var errMsgMatcherCompatible = errMsgMatcher && checkError.compatibleMessage(reason, errMsgMatcher);
+
+                    var reasonName = getReasonName(reason);
+
+                    if (negate && everyArgIsDefined) {
+                        if (errorLikeCompatible && errMsgMatcherCompatible) {
+                            that.assert(true,
+                                        null,
+                                        "expected promise not to be rejected with #{exp} but it was rejected " +
+                                        "with #{act}",
+                                        errorLikeName,
+                                        reasonName);
                         }
                     }
+                    else {
+                        if (errorLike) {
+                            that.assert(errorLikeCompatible,
+                                        "expected promise to be rejected with #{exp} but it was rejected with #{act}",
+                                        "expected promise not to be rejected with #{exp} but it was rejected " +
+                                        "with #{act}",
+                                        errorLikeName,
+                                        reasonName);
+                        }
 
-                    if (desiredReason) {
-                        that.assert(reason === desiredReason,
-                                    "expected promise to be rejected with #{exp} but it was rejected with #{act}",
-                                    "expected promise not to be rejected with #{exp}",
-                                    desiredReason,
-                                    reason);
+                        if (errMsgMatcher) {
+                            that.assert(errMsgMatcherCompatible,
+                                        "expected promise to be rejected with an error " + matcherRelation +
+                                        " #{exp} but got #{act}",
+                                        "expected promise not to be rejected with an error " + matcherRelation +
+                                        " #{exp}",
+                                        errMsgMatcher,
+                                        checkError.getMessage(reason));
+                        }
                     }
+
                     return reason;
                 }
             );
@@ -330,14 +350,9 @@
             return (new Assertion(promise, message)).to.be.fulfilled;
         };
 
-        assert.isRejected = function (promise, toTestAgainst, message) {
-            if (typeof toTestAgainst === "string") {
-                message = toTestAgainst;
-                toTestAgainst = undefined;
-            }
-
+        assert.isRejected = function (promise, errorLike, errMsgMatcher, message) {
             var assertion = (new Assertion(promise, message));
-            return toTestAgainst !== undefined ? assertion.to.be.rejectedWith(toTestAgainst) : assertion.to.be.rejected;
+            return assertion.to.be.rejectedWith(errorLike, errMsgMatcher, message);
         };
 
         assert.becomes = function (promise, value, message) {

--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -3,21 +3,21 @@
     /* istanbul ignore else */
     if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
         // NodeJS
-        module.exports = factory();
+        module.exports = factory(require("check-error"));
     } else if (typeof define === "function" && define.amd) {
         // AMD
-        define(factory);
+        define(["check-error"], factory);
     } else {
         /*global self: false */
 
         // Other environment (usually <script> tag): plug in to global chai instance directly.
-        var chaiAsPromised = factory();
+        var chaiAsPromised = factory(self.checkError);
         chai.use(chaiAsPromised);
 
         // Expose as a property of the global object so that consumers can configure the `transferPromiseness` property.
         self.chaiAsPromised = chaiAsPromised;
     }
-}(function () {
+}(function (checkError) {
     "use strict";
 
     chaiAsPromised.transferPromiseness = function (assertion, promise) {
@@ -31,6 +31,13 @@
     function chaiAsPromised(chai, utils) {
         var Assertion = chai.Assertion;
         var assert = chai.assert;
+
+        // If we are using a version of Chai that has checkError on it,
+        // we want to use that version to be consistent. Otherwise, we use
+        // what was passed to the factory.
+        if (utils.checkError) {
+            checkError = utils.checkError;
+        }
 
         function isLegacyJQueryPromise(thenable) {
             // jQuery promises are Promises/A+-compatible since 3.0.0. jQuery 3.0.0 is also the first version
@@ -154,7 +161,7 @@
                 Constructor = null;
                 message = null;
             } else if (typeof Constructor === "function") {
-                constructorName = (new Constructor()).name;
+                constructorName = checkError.getConstructorName(Constructor);
             } else {
                 Constructor = null;
             }

--- a/package.json
+++ b/package.json
@@ -30,14 +30,15 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/chai-as-promised.js.html"
   },
   "peerDependencies": {
-    "chai": ">= 2.1.2 < 4"
+    "chai": ">= 2.1.2 < 4",
+    "check-error": "^1.0.2"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "coffee-script": "1.10.0",
-    "istanbul": "0.4.1",
     "ecstatic": "^1.3.1",
     "glob": "^6.0.1",
+    "istanbul": "0.4.1",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
     "opener": "^1.4.1",

--- a/test/assert-promise-specific.coffee
+++ b/test/assert-promise-specific.coffee
@@ -3,6 +3,7 @@
 describe "Assert interface:", =>
     promise = null
     error = new Error("boo")
+    custom = "No. I am your father."
 
     describe "when the promise is fulfilled", =>
         beforeEach =>
@@ -19,12 +20,22 @@ describe "Assert interface:", =>
                 op: => assert.becomes(promise, baz: "quux")
                 message: "to deeply equal { baz: 'quux' }"
 
+        describe ".becomes(promise, incorrectValue, custom)", =>
+            shouldFail
+                op: => assert.becomes(promise, baz: "quux", custom)
+                message: custom
+
         describe ".doesNotBecome(promise, correctValue)", =>
             shouldFail
                 op: => assert.doesNotBecome(promise, foo: "bar")
                 message: "to not deeply equal { foo: 'bar' }"
         describe ".doesNotBecome(promise, incorrectValue)", =>
             shouldPass => assert.doesNotBecome(promise, baz: "quux")
+
+        describe ".doesNotBecome(promise, correctValue, custom)", =>
+            shouldFail
+                op: => assert.doesNotBecome(promise, foo: "bar", custom)
+                message: custom
 
         describe ".isRejected(promise)", =>
             shouldFail
@@ -38,7 +49,7 @@ describe "Assert interface:", =>
             shouldFail
                 op: => assert.isRejected(promise, /regexp/)
                 message: "to be rejected"
-        describe ".isRejected(promise, /regexp/)", =>
+        describe ".isRejected(promise, TypeError, /regexp/)", =>
             shouldFail
                 op: => assert.isRejected(promise, TypeError, /regexp/)
                 message: "to be rejected"
@@ -46,16 +57,31 @@ describe "Assert interface:", =>
             shouldFail
                 op: => assert.isRejected(promise, error)
                 message: "to be rejected"
+        # Chai never interprets the 3rd parameter to assert.throws as
+        # a custom error message. This is what we are checking here.
+        describe ".isRejected(promise, /quux/, custom)", =>
+            shouldFail
+                op: => assert.isRejected(promise, /quux/, custom)
+                notMessage: custom
+
 
     describe "when the promise is rejected", =>
         beforeEach =>
             promise = rejectedPromise(error)
             return undefined
 
-        describe ".isFulfilled", =>
+        describe ".isFulfilled(promise)", =>
             shouldFail
                 op: => assert.isFulfilled(promise)
                 message: "to be fulfilled"
+
+        describe ".isFulfilled(promise, custom)", =>
+            shouldFail
+                op: => assert.isFulfilled(promise, custom)
+                message: custom
+
+        describe ".isRejected(promise)", =>
+            shouldPass => assert.isRejected(promise)
 
         describe ".isRejected(promise, theError)", =>
             shouldPass => assert.isRejected(promise, error)
@@ -65,13 +91,41 @@ describe "Assert interface:", =>
                 op: => assert.isRejected(promise, new Error)
                 message: "to be rejected with"
 
+        # Chai never interprets the 3rd parameter to assert.throws as
+        # a custom error message. This is what we are checking here.
+        describe ".isRejected(promise, differentError, custom)", =>
+            shouldFail
+                op: => assert.isRejected(promise, new Error, custom)
+                notMessage: custom
+
         describe "with an Error having message 'foo bar'", =>
             beforeEach =>
                 promise = rejectedPromise(new Error("foo bar"))
                 return undefined
 
+            describe ".isRejected(promise, 'bar')", =>
+                shouldPass => assert.isRejected(promise, "bar")
+
+            describe ".isRejected(promise, 'bar', custom)", =>
+                shouldPass => assert.isRejected(promise, "bar", custom)
+
             describe ".isRejected(promise, /bar/)", =>
                 shouldPass => assert.isRejected(promise, /bar/)
+
+            describe ".isRejected(promise, /bar/, custom)", =>
+                shouldPass => assert.isRejected(promise, /bar/, custom)
+
+            describe ".isRejected(promise, 'quux')", =>
+                shouldFail
+                    op: => assert.isRejected(promise, "quux")
+                    message: "to be rejected with"
+
+            # Chai 3.5.0 never interprets the 3rd parameter to assert.throws as
+            # a custom error message. This is what we are checking here.
+            describe ".isRejected(promise, 'quux', custom)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, "quux", custom)
+                    notMessage: custom
 
             describe ".isRejected(promise, /quux/)", =>
                 shouldFail
@@ -85,40 +139,71 @@ describe "Assert interface:", =>
 
             describe ".isRejected(promise, RangeError)", =>
                 shouldPass => assert.isRejected(promise, RangeError)
+
             describe ".isRejected(promise, TypeError)", =>
                 shouldFail
                     op: => assert.isRejected(promise, TypeError)
                     message: "to be rejected"
 
-    describe "Assertion messages", =>
-        message = "No. I am your father."
+        describe "with a RangeError having a message 'foo bar'", =>
+            beforeEach =>
+                promise = rejectedPromise(new RangeError("foo bar"))
+                return undefined
 
-        describe "should be passed through for .isFulfilled(promise, message)", =>
-            shouldFail
-                op: => assert.isFulfilled(rejectedPromise(), message)
-                message: message
+            describe ".isRejected(promise, RangeError, 'foo')", =>
+                shouldPass => assert.isRejected(promise, RangeError, "foo")
 
-        describe "should be passed through for .isRejected(promise, message)", =>
-            shouldFail
-                op: => assert.isRejected(fulfilledPromise(), message)
-                message: message
+            describe ".isRejected(promise, RangeError, /bar/)", =>
+                shouldPass => assert.isRejected(promise, RangeError, /bar/)
 
-        describe "should be passed through for .isRejected(promise, TypeError, message)", =>
-            shouldFail
-                op: => assert.isRejected(fulfilledPromise(), TypeError, message)
-                message: message
+            describe ".isRejected(promise, RangeError, 'quux')", =>
+                shouldFail
+                    op: => assert.isRejected(promise, RangeError, "quux")
+                    message: "to be rejected with an error including 'quux' but got 'RangeError: foo bar'"
 
-        describe "should be passed through for .isRejected(promise, /regexp/, message)", =>
-            shouldFail
-                op: => assert.isRejected(fulfilledPromise(), /regexp/, message)
-                message: message
+            describe ".isRejected(promise, RangeError, /quux/)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, RangeError, /quux/)
+                    message: "to be rejected with an error matching /quux/ but got 'RangeError: foo bar'"
 
-        describe "should be passed through for .becomes(promise, incorrectValue, message)", =>
-            shouldFail
-                op: => assert.becomes(fulfilledPromise(baz: "quux"), foo: "bar", message)
-                message: message
+            describe ".isRejected(promise, TypeError, 'foo')", =>
+                shouldFail
+                    op: => assert.isRejected(promise, TypeError, 'foo')
+                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+            describe ".isRejected(promise, TypeError, /bar/)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, TypeError, /bar/)
+                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
 
-        describe "should be passed through for .doesNotBecome(promise, incorrectValue, message)", =>
-            shouldFail
-                op: => assert.doesNotBecome(fulfilledPromise(foo: "bar"), foo: "bar", message)
-                message: message
+            describe ".isRejected(promise, TypeError, 'quux')", =>
+                shouldFail
+                    op: => assert.isRejected(promise, TypeError, 'quux')
+                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+            describe ".isRejected(promise, TypeError, /quux/)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, TypeError, /quux/)
+                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+
+            describe ".isRejected(promise, RangeError, 'foo', custom)", =>
+                shouldPass => assert.isRejected(promise, RangeError, "foo", custom)
+
+            describe ".isRejected(promise, RangeError, /bar/, custom)", =>
+                shouldPass => assert.isRejected(promise, RangeError, /bar/, custom)
+
+            describe ".isRejected(promise, RangeError, 'quux', custom)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, RangeError, "quux", custom)
+                    message: custom
+
+            describe ".isRejected(promise, RangeError, /quux/, custom)", =>
+                shouldFail
+                    op: => assert.isRejected(promise, RangeError, /quux/, custom)
+                    message: custom
+
+            describe ".isRejected(promise, RangeError, undefined, custom)", =>
+                shouldPass => assert.isRejected(promise, RangeError, undefined, custom)
+
+            describe ".isRejected(promise, TypeError, undefined, custom)", =>
+                shouldFail
+                op: => assert.isRejected(promise, TypeError, undefined, custom)
+                message: custom

--- a/test/assert-promise-specific.coffee
+++ b/test/assert-promise-specific.coffee
@@ -159,30 +159,30 @@ describe "Assert interface:", =>
             describe ".isRejected(promise, RangeError, 'quux')", =>
                 shouldFail
                     op: => assert.isRejected(promise, RangeError, "quux")
-                    message: "to be rejected with an error including 'quux' but got 'RangeError: foo bar'"
+                    message: "to be rejected with an error including 'quux' but got 'foo bar'"
 
             describe ".isRejected(promise, RangeError, /quux/)", =>
                 shouldFail
                     op: => assert.isRejected(promise, RangeError, /quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'RangeError: foo bar'"
+                    message: "to be rejected with an error matching /quux/ but got 'foo bar'"
 
             describe ".isRejected(promise, TypeError, 'foo')", =>
                 shouldFail
                     op: => assert.isRejected(promise, TypeError, 'foo')
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
             describe ".isRejected(promise, TypeError, /bar/)", =>
                 shouldFail
                     op: => assert.isRejected(promise, TypeError, /bar/)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".isRejected(promise, TypeError, 'quux')", =>
                 shouldFail
                     op: => assert.isRejected(promise, TypeError, 'quux')
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
             describe ".isRejected(promise, TypeError, /quux/)", =>
                 shouldFail
                     op: => assert.isRejected(promise, TypeError, /quux/)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".isRejected(promise, RangeError, 'foo', custom)", =>
                 shouldPass => assert.isRejected(promise, RangeError, "foo", custom)

--- a/test/browser/template.html
+++ b/test/browser/template.html
@@ -8,6 +8,7 @@
 
     <script src="http://coffeescript.org/extras/coffee-script.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/check-error/check-error.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../lib/chai-as-promised.js"></script>
 

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -80,7 +80,7 @@ describe "Promise-specific extensions:", =>
         describe ".rejectedWith(errorInstance)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(error)
-                message: "to be rejected with [Error: boo] but it was fulfilled with 42"
+                message: "to be rejected with 'Error: boo' but it was fulfilled with 42"
 
         describe ".not.rejected", =>
             shouldPass => promise.should.not.be.rejected
@@ -109,7 +109,7 @@ describe "Promise-specific extensions:", =>
         describe ".fulfilled", =>
             shouldFail
                 op: => promise.should.be.fulfilled
-                message: "to be fulfilled but it was rejected with [Error: boo]"
+                message: "to be fulfilled but it was rejected with 'Error: boo'"
 
         describe ".not.fulfilled", =>
             shouldPass => promise.should.not.be.fulfilled
@@ -127,7 +127,7 @@ describe "Promise-specific extensions:", =>
         describe ".not.rejected", =>
             shouldFail
                 op: => promise.should.not.be.rejected
-                message: "not to be rejected but it was rejected with [Error: boo]"
+                message: "not to be rejected but it was rejected with 'Error: boo'"
         describe ".rejected should allow chaining", =>
             shouldPass => promise.should.be.rejected.and.eventually.have.property("myProp")
 
@@ -141,7 +141,7 @@ describe "Promise-specific extensions:", =>
         describe ".not.rejectedWith(theError)", =>
             shouldFail
                 op: => promise.should.not.be.rejectedWith(error)
-                message: "not to be rejected with [Error: boo]"
+                message: "not to be rejected with 'Error: boo'"
 
         describe ".rejectedWith(theError) should allow chaining", =>
             shouldPass => promise.should.be.rejectedWith(error).and.eventually.have.property("myProp")
@@ -153,7 +153,7 @@ describe "Promise-specific extensions:", =>
         describe ".rejectedWith(differentError)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(new Error)
-                message: "to be rejected with [Error] but it was rejected with [Error: boo]"
+                message: "to be rejected with 'Error' but it was rejected with 'Error: boo'"
 
         describe ".not.rejectedWith(differentError)", =>
             shouldPass => promise.should.not.be.rejectedWith(new Error)
@@ -164,7 +164,7 @@ describe "Promise-specific extensions:", =>
         describe ".rejectedWith(differentError, custom)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(new Error, custom)
-                message: "to be rejected with [Error] but it was rejected with [Error: boo]"
+                message: "to be rejected with 'Error' but it was rejected with 'Error: boo'"
                 notMessage: custom
 
         describe ".not.rejectedWith(differentError, custom)", =>
@@ -194,7 +194,7 @@ describe "Promise-specific extensions:", =>
             describe ".rejectedWith('quux')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith("quux")
-                    message: "to be rejected with an error including 'quux' but got 'Error: foo bar'"
+                    message: "to be rejected with an error including 'quux' but got 'foo bar'"
 
             describe ".not.rejectedWith('quux')", =>
                 shouldPass => promise.should.be.not.rejectedWith("quux")
@@ -202,7 +202,7 @@ describe "Promise-specific extensions:", =>
             describe ".rejectedWith(/quux/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(/quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'Error: foo bar'"
+                    message: "to be rejected with an error matching /quux/ but got 'foo bar'"
 
             describe ".not.rejectedWith(/quux/)", =>
                 shouldPass => promise.should.not.be.rejectedWith(/quux/)
@@ -239,18 +239,18 @@ describe "Promise-specific extensions:", =>
             describe ".not.rejectedWith(RangeError)", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError)
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError]"
+                    message: "not to be rejected with 'RangeError' but it was rejected with 'RangeError'"
 
             describe ".rejectedWith(TypeError)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(TypeError)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError'"
 
             # Case for issue #64.
             describe ".rejectedWith(Array)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(Array)
-                    message: "to be rejected with 'Array' but it was rejected with [RangeError]"
+                    message: "to be rejected with 'Array' but it was rejected with 'RangeError'"
 
             describe ".not.rejectedWith(TypeError)", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError)
@@ -266,7 +266,7 @@ describe "Promise-specific extensions:", =>
             describe ".not.rejectedWith(RangeError, 'foo')", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError, "foo")
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+                    message: "not to be rejected with 'RangeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".rejectedWith(RangeError, /bar/)", =>
                 shouldPass => promise.should.be.rejectedWith(RangeError, /bar/)
@@ -274,43 +274,43 @@ describe "Promise-specific extensions:", =>
             describe ".not.rejectedWith(RangeError, /bar/)", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError, /bar/)
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+                    message: "not to be rejected with 'RangeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".rejectedWith(RangeError, 'quux')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(RangeError, "quux")
-                    message: "to be rejected with an error including 'quux' but got 'RangeError: foo bar'"
+                    message: "to be rejected with an error including 'quux' but got 'foo bar'"
             describe ".rejectedWith(RangeError, /quux/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(RangeError, /quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'RangeError: foo bar'"
+                    message: "to be rejected with an error matching /quux/ but got 'foo bar'"
 
             describe ".rejectedWith(TypeError, 'foo')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(TypeError, 'foo')
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
             describe ".rejectedWith(TypeError, /bar/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(TypeError, /bar/)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".rejectedWith(TypeError, 'quux')", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(TypeError, 'quux')
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
             describe ".rejectedWith(TypeError, /quux/)", =>
                 shouldFail
                     op: => promise.should.be.rejectedWith(TypeError, /quux/)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
+                    message: "to be rejected with 'TypeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".not.rejectedWith(RangeError, 'foo')", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError, 'foo')
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+                    message: "not to be rejected with 'RangeError' but it was rejected with 'RangeError: foo bar'"
             describe ".not.rejectedWith(RangeError, /bar/)", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError, /bar/)
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+                    message: "not to be rejected with 'RangeError' but it was rejected with 'RangeError: foo bar'"
 
             describe ".not.rejectedWith(RangeError, 'quux')", =>
                 shouldPass => promise.should.not.be.rejectedWith(RangeError, 'quux')

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -199,6 +199,12 @@ describe "Promise-specific extensions:", =>
                     op: => promise.should.be.rejectedWith(TypeError)
                     message: "to be rejected with 'TypeError' but it was rejected with [RangeError]"
 
+            # Case for issue #64.
+            describe ".rejectedWith(Array)", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith(Array)
+                    message: "to be rejected with 'Array' but it was rejected with [RangeError]"
+
             describe ".not.rejectedWith(TypeError)", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError)
 

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -313,23 +313,13 @@ describe "Promise-specific extensions:", =>
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".not.rejectedWith(RangeError, 'quux')", =>
-                shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError, 'quux')
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+                shouldPass => promise.should.not.be.rejectedWith(RangeError, 'quux')
             describe ".not.rejectedWith(RangeError, /quux/)", =>
-                shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError, /quux/)
-                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
-
+                shouldPass => promise.should.not.be.rejectedWith(RangeError, /quux/)
             describe ".not.rejectedWith(TypeError, 'foo')", =>
-                shouldFail
-                    op: => promise.should.not.be.rejectedWith(TypeError, "foo")
-                    message: "not to be rejected with an error including 'foo'"
+                shouldPass => promise.should.not.be.rejectedWith(TypeError, "foo")
             describe ".not.rejectedWith(TypeError, /bar/)", =>
-                shouldFail
-                    op: => promise.should.not.be.rejectedWith(TypeError, /bar/)
-                    message: "not to be rejected with an error matching /bar/"
-
+                shouldPass => promise.should.not.be.rejectedWith(TypeError, /bar/)
             describe ".not.rejectedWith(TypeError, 'quux')", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError, "quux")
             describe ".not.rejectedWith(TypeError, /quux/)", =>

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -3,6 +3,7 @@
 describe "Promise-specific extensions:", =>
     promise = null
     error = new Error("boo")
+    custom = "No. I am your father."
 
     assertingDoneFactory = (done) =>
         (result) =>
@@ -89,8 +90,14 @@ describe "Promise-specific extensions:", =>
         describe ".rejected", =>
             shouldPass => promise.should.be.rejected
 
+        describe ".not.rejected", =>
+            shouldFail
+                op: => promise.should.not.be.rejected
+                message: "not to be rejected but it was rejected with [Error: boo]"
+
         describe ".rejectedWith(theError)", =>
             shouldPass => promise.should.be.rejectedWith(error)
+
         describe ".not.rejectedWith(theError)", =>
             shouldFail
                 op: => promise.should.not.be.rejectedWith(error)
@@ -100,8 +107,21 @@ describe "Promise-specific extensions:", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(new Error)
                 message: "to be rejected with [Error] but it was rejected with [Error: boo]"
+
         describe ".not.rejectedWith(differentError)", =>
             shouldPass => promise.should.not.be.rejectedWith(new Error)
+
+        # Chai 3.5.0 never interprets the 2nd paramter to
+        # expect(fn).to.throw(a, b) as a custom error message. This is
+        # what we are testing here.
+        describe ".rejectedWith(differentError, custom)", =>
+            shouldFail
+                op: => promise.should.be.rejectedWith(new Error, custom)
+                message: "to be rejected with [Error] but it was rejected with [Error: boo]"
+                notMessage: custom
+
+        describe ".not.rejectedWith(differentError, custom)", =>
+            shouldPass => promise.should.not.be.rejectedWith(new Error, custom)
 
         describe "with an Error having message 'foo bar'", =>
             beforeEach =>
@@ -110,31 +130,56 @@ describe "Promise-specific extensions:", =>
 
             describe ".rejectedWith('foo')", =>
                 shouldPass => promise.should.be.rejectedWith("foo")
-            describe ".rejectedWith(/bar/)", =>
-                shouldPass => promise.should.be.rejectedWith(/bar/)
-
-            describe ".rejectedWith('quux')", =>
-                shouldFail
-                    op: => promise.should.be.rejectedWith("quux")
-                    message: "to be rejected with an error including 'quux' but got 'Error: foo bar'"
-            describe ".rejectedWith(/quux/)", =>
-                shouldFail
-                    op: => promise.should.be.rejectedWith(/quux/)
-                    message: "to be rejected with an error matching /quux/ but got 'Error: foo bar'"
 
             describe ".not.rejectedWith('foo')", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith("foo")
                     message: "not to be rejected with an error including 'foo'"
+
+            describe ".rejectedWith(/bar/)", =>
+                shouldPass => promise.should.be.rejectedWith(/bar/)
+
             describe ".not.rejectedWith(/bar/)", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(/bar/)
                     message: "not to be rejected with an error matching /bar/"
 
+            describe ".rejectedWith('quux')", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith("quux")
+                    message: "to be rejected with an error including 'quux' but got 'Error: foo bar'"
+
             describe ".not.rejectedWith('quux')", =>
-                shouldPass => promise.should.not.be.rejectedWith("quux")
+                shouldPass => promise.should.be.not.rejectedWith("quux")
+
+            describe ".rejectedWith(/quux/)", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith(/quux/)
+                    message: "to be rejected with an error matching /quux/ but got 'Error: foo bar'"
+
             describe ".not.rejectedWith(/quux/)", =>
                 shouldPass => promise.should.not.be.rejectedWith(/quux/)
+
+            # Chai 3.5.0 never interprets the 2nd paramter to
+            # expect(fn).to.throw(a, b) as a custom error
+            # message. This is what we are testing here.
+            describe ".rejectedWith('foo', custom)", =>
+                shouldPass => promise.should.be.rejectedWith("foo", custom)
+
+            describe ".not.rejectedWith('foo', custom)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith("foo", custom)
+                    message: "not to be rejected with an error including 'foo'"
+                    notMessage: custom
+
+            describe ".rejectedWith(/bar/, custom)", =>
+                shouldPass => promise.should.be.rejectedWith(/bar/, custom)
+
+            describe ".not.rejectedWith(/bar/, custom)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(/bar/)
+                    message: "not to be rejected with an error matching /bar/"
+                    notMessage: custom
 
         describe "with a RangeError", =>
             beforeEach =>
@@ -143,15 +188,17 @@ describe "Promise-specific extensions:", =>
 
             describe ".rejectedWith(RangeError)", =>
                 shouldPass => promise.should.be.rejectedWith(RangeError)
-            describe ".rejectedWith(TypeError)", =>
-                shouldFail
-                    op: => promise.should.be.rejectedWith(TypeError)
-                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError]"
 
             describe ".not.rejectedWith(RangeError)", =>
                 shouldFail
                     op: => promise.should.not.be.rejectedWith(RangeError)
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError]"
+
+            describe ".rejectedWith(TypeError)", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith(TypeError)
+                    message: "to be rejected with 'TypeError' but it was rejected with [RangeError]"
+
             describe ".not.rejectedWith(TypeError)", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError)
 
@@ -162,8 +209,19 @@ describe "Promise-specific extensions:", =>
 
             describe ".rejectedWith(RangeError, 'foo')", =>
                 shouldPass => promise.should.be.rejectedWith(RangeError, "foo")
+
+            describe ".not.rejectedWith(RangeError, 'foo')", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(RangeError, "foo")
+                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
+
             describe ".rejectedWith(RangeError, /bar/)", =>
                 shouldPass => promise.should.be.rejectedWith(RangeError, /bar/)
+
+            describe ".not.rejectedWith(RangeError, /bar/)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(RangeError, /bar/)
+                    message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".rejectedWith(RangeError, 'quux')", =>
                 shouldFail
@@ -176,38 +234,38 @@ describe "Promise-specific extensions:", =>
 
             describe ".rejectedWith(TypeError, 'foo')", =>
                 shouldFail
-                    op: => promise.should.be.rejectedWith(TypeError)
+                    op: => promise.should.be.rejectedWith(TypeError, 'foo')
                     message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
             describe ".rejectedWith(TypeError, /bar/)", =>
                 shouldFail
-                    op: => promise.should.be.rejectedWith(TypeError)
+                    op: => promise.should.be.rejectedWith(TypeError, /bar/)
                     message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".rejectedWith(TypeError, 'quux')", =>
                 shouldFail
-                    op: => promise.should.be.rejectedWith(TypeError)
+                    op: => promise.should.be.rejectedWith(TypeError, 'quux')
                     message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
             describe ".rejectedWith(TypeError, /quux/)", =>
                 shouldFail
-                    op: => promise.should.be.rejectedWith(TypeError)
+                    op: => promise.should.be.rejectedWith(TypeError, /quux/)
                     message: "to be rejected with 'TypeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".not.rejectedWith(RangeError, 'foo')", =>
                 shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError)
+                    op: => promise.should.not.be.rejectedWith(RangeError, 'foo')
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
             describe ".not.rejectedWith(RangeError, /bar/)", =>
                 shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError)
+                    op: => promise.should.not.be.rejectedWith(RangeError, /bar/)
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".not.rejectedWith(RangeError, 'quux')", =>
                 shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError)
+                    op: => promise.should.not.be.rejectedWith(RangeError, 'quux')
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
             describe ".not.rejectedWith(RangeError, /quux/)", =>
                 shouldFail
-                    op: => promise.should.not.be.rejectedWith(RangeError)
+                    op: => promise.should.not.be.rejectedWith(RangeError, /quux/)
                     message: "not to be rejected with 'RangeError' but it was rejected with [RangeError: foo bar]"
 
             describe ".not.rejectedWith(TypeError, 'foo')", =>
@@ -223,6 +281,53 @@ describe "Promise-specific extensions:", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError, "quux")
             describe ".not.rejectedWith(TypeError, /quux/)", =>
                 shouldPass => promise.should.not.be.rejectedWith(TypeError, /quux/)
+            describe ".rejectedWith(RangeError, 'foo', custom)", =>
+                shouldPass => promise.should.be.rejectedWith(RangeError, "foo", custom)
+
+            describe ".not.rejectedWith(RangeError, 'foo', custom)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(RangeError, "foo", custom)
+                    message: custom
+
+            describe ".rejectedWith(RangeError, /bar/, custom)", =>
+                shouldPass => promise.should.be.rejectedWith(RangeError, /bar/, custom)
+
+            describe ".not.rejectedWith(RangeError, /bar/, custom)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(RangeError, /bar/, custom)
+                    message: custom
+
+            describe ".rejectedWith(RangeError, 'quux', custom)", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith(RangeError, "quux", custom)
+                    message: custom
+
+            describe ".not.rejectedWith(TypeError, 'quux', custom)", =>
+                shouldPass => promise.should.not.be.rejectedWith(TypeError, "quux", custom)
+
+            describe ".rejectedWith(RangeError, /quux/, custom)", =>
+                shouldFail
+                    op: => promise.should.be.rejectedWith(RangeError, /quux/, custom)
+                    message: custom
+
+            describe ".not.rejectedWith(TypeError, /quux/, custom)", =>
+                shouldPass => promise.should.not.be.rejectedWith(TypeError, /quux/, custom)
+
+            describe ".rejectedWith(RangeError, undefined, custom)", =>
+                shouldPass => promise.should.be.rejectedWith(RangeError, undefined, custom)
+
+            describe ".not.rejectedWith(RangeError, undefined, custom)", =>
+                shouldFail
+                    op: => promise.should.not.be.rejectedWith(RangeError, undefined, custom)
+                    message: custom
+
+            describe ".rejectedWith(TypeError, undefined, custom)", =>
+                shouldFail
+                op: => promise.should.be.rejectedWith(TypeError, undefined, custom)
+                message: custom
+
+            describe ".not.rejectedWith(TypeError, undefined, custom)", =>
+                shouldPass => promise.should.not.be.rejectedWith(TypeError, undefined, custom)
 
         describe ".should.notify(done)", =>
             it "should fail the test with the original error", (done) =>

--- a/test/should-promise-specific.coffee
+++ b/test/should-promise-specific.coffee
@@ -3,6 +3,7 @@
 describe "Promise-specific extensions:", =>
     promise = null
     error = new Error("boo")
+    error.myProp = ["myProp value"]
     custom = "No. I am your father."
 
     assertingDoneFactory = (done) =>
@@ -16,45 +17,70 @@ describe "Promise-specific extensions:", =>
 
     describe "when the promise is fulfilled", =>
         beforeEach =>
-            promise = fulfilledPromise()
+            promise = fulfilledPromise(42)
             return undefined
 
         describe ".fulfilled", =>
             shouldPass => promise.should.be.fulfilled
+
+        describe ".fulfilled passes the fulfilled value", =>
+            shouldPass => promise.should.be.fulfilled.then (passedValue) =>
+                passedValue.should.equal(42)
+
+        describe ".fulfilled allows chaining", =>
+            shouldPass => promise.should.be.fulfilled.and.eventually.equal(42)
+
         describe ".not.fulfilled", =>
             shouldFail
                 op: => promise.should.not.be.fulfilled
-                message: "not to be fulfilled but it was fulfilled with undefined"
+                message: "not to be fulfilled but it was fulfilled with 42"
 
         describe ".rejected", =>
             shouldFail
               op: => promise.should.be.rejected
-              message: "to be rejected but it was fulfilled with undefined"
+              message: "to be rejected but it was fulfilled with 42"
+
+        describe ".not.rejected passes the fulfilled value", =>
+            shouldPass => promise.should.not.be.rejected.then (passedValue) =>
+                passedValue.should.equal(42)
+
+        # .not inverts all following assertions so the following test is
+        # equivalent to promise.should.eventually.not.equal(31)
+        describe ".not.rejected allows chaining", =>
+            shouldPass => promise.should.not.be.rejected.and.eventually.equal(31)
+
         describe ".rejectedWith(TypeError)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(TypeError)
-                message: "to be rejected with 'TypeError' but it was fulfilled with undefined"
+                message: "to be rejected with 'TypeError' but it was fulfilled with 42"
+        describe ".not.rejectedWith(TypeError) passes the fulfilled value", =>
+            shouldPass => promise.should.not.be.rejectedWith(TypeError).then (passedValue) =>
+                passedValue.should.equal(42)
+
+        describe ".not.rejectedWith(TypeError) allows chaining", =>
+            shouldPass => promise.should.not.be.rejectedWith(TypeError).and.eventually.equal(31)
+
         describe ".rejectedWith('message substring')", =>
             shouldFail
                 op: => promise.should.be.rejectedWith("message substring")
                 message: "to be rejected with an error including 'message substring' but it was fulfilled with " +
-                         "undefined"
+                         "42"
         describe ".rejectedWith(/regexp/)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(/regexp/)
-                message: "to be rejected with an error matching /regexp/ but it was fulfilled with undefined"
+                message: "to be rejected with an error matching /regexp/ but it was fulfilled with 42"
         describe ".rejectedWith(TypeError, 'message substring')", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(TypeError, "message substring")
-                message: "to be rejected with 'TypeError' but it was fulfilled with undefined"
+                message: "to be rejected with 'TypeError' but it was fulfilled with 42"
         describe ".rejectedWith(TypeError, /regexp/)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(TypeError, /regexp/)
-                message: "to be rejected with 'TypeError' but it was fulfilled with undefined"
+                message: "to be rejected with 'TypeError' but it was fulfilled with 42"
         describe ".rejectedWith(errorInstance)", =>
             shouldFail
                 op: => promise.should.be.rejectedWith(error)
-                message: "to be rejected with [Error: boo] but it was fulfilled with undefined"
+                message: "to be rejected with [Error: boo] but it was fulfilled with 42"
 
         describe ".not.rejected", =>
             shouldPass => promise.should.not.be.rejected
@@ -84,8 +110,16 @@ describe "Promise-specific extensions:", =>
             shouldFail
                 op: => promise.should.be.fulfilled
                 message: "to be fulfilled but it was rejected with [Error: boo]"
+
         describe ".not.fulfilled", =>
             shouldPass => promise.should.not.be.fulfilled
+
+        describe ".not.fulfilled should allow chaining", =>
+            shouldPass => promise.should.not.be.fulfilled.and.eventually.have.property("nonexistent")
+
+        describe ".not.fulfilled should pass the rejection reason", =>
+            shouldPass => promise.should.not.be.fulfilled.then (passedError) =>
+                passedError.should.equal(error)
 
         describe ".rejected", =>
             shouldPass => promise.should.be.rejected
@@ -94,6 +128,12 @@ describe "Promise-specific extensions:", =>
             shouldFail
                 op: => promise.should.not.be.rejected
                 message: "not to be rejected but it was rejected with [Error: boo]"
+        describe ".rejected should allow chaining", =>
+            shouldPass => promise.should.be.rejected.and.eventually.have.property("myProp")
+
+        describe ".rejected passes the rejection reason", =>
+            shouldPass => promise.should.be.rejected.then (passedError) =>
+                passedError.should.equal(error)
 
         describe ".rejectedWith(theError)", =>
             shouldPass => promise.should.be.rejectedWith(error)
@@ -102,6 +142,13 @@ describe "Promise-specific extensions:", =>
             shouldFail
                 op: => promise.should.not.be.rejectedWith(error)
                 message: "not to be rejected with [Error: boo]"
+
+        describe ".rejectedWith(theError) should allow chaining", =>
+            shouldPass => promise.should.be.rejectedWith(error).and.eventually.have.property("myProp")
+
+        describe ".rejectedWith(theError) passes the rejection reason", =>
+            shouldPass => promise.should.be.rejectedWith(error).then (passedError) =>
+                passedError.should.equal(error)
 
         describe ".rejectedWith(differentError)", =>
             shouldFail

--- a/test/support/common.js
+++ b/test/support/common.js
@@ -28,19 +28,18 @@ global.shouldFail = function (options) {
 
     it("should return a promise rejected with an assertion error", function (done) {
         promiseProducer().then(function () {
-            done(new Error("Expected promise to be rejected with an assertion error, but it was fulfilled"));
+            throw new Error("Expected promise to be rejected with an assertion error, but it was fulfilled");
         }, function (reason) {
             if (Object(reason) !== reason || reason.constructor.name !== "AssertionError") {
-                done(new Error("Expected promise to be rejected with an AssertionError but it was rejected with " +
-                               reason));
-            } else {
-                if (desiredMessageSubstring && reason.message.indexOf(desiredMessageSubstring) === -1) {
-                    done(new Error("Expected promise to be rejected with an AssertionError containing \"" +
-                                   desiredMessageSubstring + "\" but it was rejected with " + reason));
-                } else {
-                    done();
-                }
+                throw new Error("Expected promise to be rejected with an AssertionError but it was rejected with " +
+                                reason);
             }
-        });
+
+            if (desiredMessageSubstring && reason.message.indexOf(desiredMessageSubstring) === -1) {
+                throw new Error("Expected promise to be rejected with an AssertionError containing \"" +
+                                desiredMessageSubstring + "\" but it was rejected with " + reason);
+            }
+        }).then(done, done);
+
     });
 };

--- a/test/support/common.js
+++ b/test/support/common.js
@@ -25,6 +25,7 @@ global.shouldPass = function (promiseProducer) {
 global.shouldFail = function (options) {
     var promiseProducer = options.op;
     var desiredMessageSubstring = options.message;
+    var nonDesiredMessageSubstring = options.notMessage;
 
     it("should return a promise rejected with an assertion error", function (done) {
         promiseProducer().then(function () {
@@ -38,6 +39,11 @@ global.shouldFail = function (options) {
             if (desiredMessageSubstring && reason.message.indexOf(desiredMessageSubstring) === -1) {
                 throw new Error("Expected promise to be rejected with an AssertionError containing \"" +
                                 desiredMessageSubstring + "\" but it was rejected with " + reason);
+            }
+
+            if (nonDesiredMessageSubstring && reason.message.indexOf(nonDesiredMessageSubstring) !== -1) {
+                throw new Error("Expected promise to be rejected with an AssertionError not containing \"" +
+                                nonDesiredMessageSubstring + "\" but it was rejected with " + reason);
             }
         }).then(done, done);
 


### PR DESCRIPTION
This PR takes care primarily of #47. I've also dealt with #64 and #113 while working on this.

Some notes on this PR...

**This PR introduces a bunch of breaking changes.** There's no way around it if our goal is to have `.should.be.rejectedWith` and `assert.isRejected` mirror what Chai does with `should.throw` and `assert.throws`.

Notably:

* `.fulfilled`, `.rejected` and `.rejectedWith` now change the `object` flag when they are successful. Code relying on the old behavior will fail, or in some cases it could be successful but not test what it used to test. Code that used chaining with these assertions should be hand-inspected and modified as needed.

* `.not.rejectedWith` now has different semantics. In previous versions `foo.should.not.be.rejectedWith(Constructor, 'string')` would fail if the error was rejected with an instance of `Constructor`. If it was rejected with an instance of `Constructor` then the next parameter would not even be inspected. It would also fail if the error was rejected with an instance of something else that had for message `'string'`.

   This was different from how `foo.should.not.throw(Constructor, 'string')` has been behaving in Chai. In Chai, this test would fail only if the error thrown is an instance of `Constructor` **and** if it has the message `'string'`. A `Constructor` instance with a different message would not cause a failure. An instance of a different class with the message `'string'` would not cause a failure.

   **Tests that were failing will now pass due to this change.** All instances of `.not.rejectedWith` need inspection to see whether they need to be modified in light of the new semantics.

====

While fixing #113 I've done the following:

- `.fulfilled`, `.not.rejected` and `.not.rejectedWith` when successful:

  * The promise they return is fulfilled with the same value as the promise they were testing.

- When `.not.fulfilled`, `.rejected` and `.rejectedWith` are successful:

  * The promise they return is fulfilled with the rejection reason.

In all cases, when they fail, the promise they return is rejected and has for reason the assertion that failed.

The changes above make it so that (as mentioned before) the `object` flag is automatically set when the promise returned is resolved, and thus also allows chaining. (I've tested chaining independently.)

====

I have flip-flopped on whether the `eventually` flag should be automatically set by `.fulfilled` `.rejected` and `.rejectedWith`. If it is set, then the tests that follow *forcibly* pertain to the fulfilled value of the promise they return. If it is not set, then if the user wants to test the fulfilled value, they have to use `.eventually`. Otherwise the tests are done on the promise itself.

The one thing that I don't like about not setting the `eventually`, it is *really* easy to end up not testing what one think they're testing. One may write this:

    promise.should.not.be.fulfilled.and.have.property("nonexistent")

When one means to write this:

    promise.should.not.be.fulfilled.and.eventually.have.property("nonexistent")

The first will check that the *promise* returned by `fulfilled` does not have the property `nonexistent`. The second checks that the *rejection reason* does not have the property `nonexistent`.

====

Using `check-error` turned out to be a bit problematic.

Chai passes `check-error` to plugins as the `checkError` field on the `utils` parameter. However, no version of Chai has been released yet that has this field on `utils`. (Probably the next version after 3.5.0 would do it. Note that I've tried running chai-as-promised with the latest `master` of Chai and got a whole slew of errors. Fixing `chai-as-promised` to work with Chai@master is beyond the scope of my task.) It seems to me making chai-as-promised require that future version as a minimum peer dependency would be too restrictive.

In the code proposed here, chai-as-promised now does this: if `utils.checkError` exists, use that. Otherwise, it use an instance of `check-error` loaded from the module system (or obtained globally
when `chai-as-promised` is loaded through `script`).
