### PR TITLE
Set eslint as devDependency instead of dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/chai-as-promised.js.html"
   },
   "dependencies": {
-    "check-error": "^1.0.2",
-    "eslint": "^3.19.0"
+    "check-error": "^1.0.2"
   },
   "peerDependencies": {
     "chai": ">= 2.1.2 < 5"
   },
   "devDependencies": {
     "chai": "^4.0.2",
+    "eslint": "^3.19.0",
     "istanbul": "0.4.5",
     "mocha": "^3.4.2"
   }


### PR DESCRIPTION
Causes conflicts in `./node_modules/.bin` if there are different versions of eslint used by consumer. Happens with current yarn. Eslint isn't a dependency on this library to run.