### PR TITLE
Fixes stack trace for 'eventually' assertions

### DIFF
--- a/lib/chai-as-promised.js
+++ b/lib/chai-as-promised.js
@@ -79,6 +79,17 @@ module.exports = (chai, utils) => {
     function getReasonName(reason) {
         return reason instanceof Error ? reason.toString() : checkError.getConstructorName(reason);
     }
+    
+    function getOriginalStackTrace() {
+      // Header - depends on engine
+      // We omit place of creation and place of execution (2 lines + optionally a header)
+
+      const stack = new Error().stack;
+      const stackLines = stack.split('\n');
+      const hasHeader = stackLines[0].startsWith("Error");
+      const linesToOmit = hasHeader ? 3 : 2;
+      return stackLines.slice(linesToOmit).join('\n');
+    }
 
     // Grab these first, before we modify `Assertion.prototype`.
 
@@ -290,6 +301,8 @@ module.exports = (chai, utils) => {
             return assertion;
         }
 
+        const originalStackTrace = getOriginalStackTrace();
+
         const derivedPromise = getBasePromise(assertion).then(value => {
             // Set up the environment for the asserter to actually run: `_obj` should be the fulfillment value, and
             // now that we have the value, we're no longer in "eventually" mode, so we won't run any of this code,
@@ -305,6 +318,11 @@ module.exports = (chai, utils) => {
             // flag), we need to communicate this value change to subsequent chained asserters. Since we build a
             // promise chain paralleling the asserter chain, we can use it to communicate such changes.
             return assertion._obj;
+        }).catch(err => {
+          err.stack = err.stack
+            .concat('\n')
+            .concat(originalStackTrace)
+          throw err;
         });
 
         module.exports.transferPromiseness(assertion, derivedPromise);


### PR DESCRIPTION
In use cases `expect(promise).to.eventually` the stack trace would end up on:
```
      at getBasePromise.then.then.newArgs (node_modules/chai-as-promised/lib/chai-as-promised.js:316:22)
```
Which doesn't help navigating to the test that failed, this PR modifies the stack trace to include the point of origin of the assertion.

```
      at getBasePromise.then.then.newArgs (node_modules/chai-as-promised/lib/chai-as-promised.js:316:22)
      at <anonymous>
      at Proxy.<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:267:20)
      at Proxy.overwritingMethodWrapper (node_modules/chai/lib/chai/utils/overwriteMethod.js:78:33)
      at Context.it (packages/xxx/testfile.spec.js:58:12)
```